### PR TITLE
Add option to override default "not found" (404) response allowing to inject CORS headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,13 @@ const mockr = new ServerMockr({
   controlServerPort: 6001,
   mockServerPort: 6002,
   multipleScenarioRunners: true,
-  globals: { globalValue: "value" }
+  globals: { globalValue: "value" },
+  notFoundResponse: {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+    status: 404,
+    body: "server-mockr: Not Found",
+  }
 });
 ```

--- a/src/mock-server/Config.ts
+++ b/src/mock-server/Config.ts
@@ -1,6 +1,6 @@
 import { Expectation } from "./Expectation";
 import { Scenario } from "./Scenario";
-import { GlobalsValue } from "./Values";
+import { GlobalsValue, ResponseValue } from "./Values";
 
 /*
  * CONFIG
@@ -14,6 +14,7 @@ export interface Config {
   mockServerPort: number;
   multipleScenarioRunners: boolean;
   scenarios: Scenario[];
+  notFoundResponse?: ResponseValue;
 }
 
 export interface InitialConfig extends Partial<Config> {}

--- a/src/mock-server/ServerManager.ts
+++ b/src/mock-server/ServerManager.ts
@@ -118,7 +118,7 @@ export class ServerManager {
 
     const finalResponse: ResponseValue = handled
       ? response
-      : createNotFoundResponseValue();
+      : this.config.notFoundResponse || createNotFoundResponseValue();
 
     await respondWithResponseValue(res, finalResponse);
 


### PR DESCRIPTION
I added a config option to the `ServerMockr` config to override the default ResponseValue when an incoming request is not handled by any of the loaded scenarios. This override can be used to add global CORS headers to the response value.

```
const mockr = new ServerMockr({       
  controlServerPort: 6001, 
  mockServerPort: 6002,      
  multipleScenarioRunners: true,      
  globals: { globalValue: "value" },                
  notFoundResponse: {            
    headers: {                                 
      "Content-Type": "text/plain",  
    },                                             
    status: 404,           
    body: "server-mockr: Not Found",                        
  }                      
});
```